### PR TITLE
fix api auth issue

### DIFF
--- a/app/_components/FeatureComponents/User/UserSwitcher.tsx
+++ b/app/_components/FeatureComponents/User/UserSwitcher.tsx
@@ -52,8 +52,13 @@ export const UserSwitcher = ({
   return (
     <div className={`relative ${className}`}>
       <Button
+        type="button"
         variant="outline"
-        onClick={() => setIsOpen(!isOpen)}
+        onClick={(e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          setIsOpen(!isOpen);
+        }}
         className="w-full justify-between"
       >
         <div className="flex items-center gap-2">
@@ -67,8 +72,11 @@ export const UserSwitcher = ({
         <div className="absolute top-full left-0 right-0 mt-1 bg-background border border-border rounded-md shadow-lg z-50 max-h-48 overflow-y-auto">
           {users.map((user) => (
             <button
+              type="button"
               key={user}
-              onClick={() => {
+              onClick={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
                 onUserChange(user);
                 setIsOpen(false);
               }}

--- a/app/_utils/api-auth-utils.ts
+++ b/app/_utils/api-auth-utils.ts
@@ -56,16 +56,19 @@ export async function requireAuth(
     return null;
   }
 
-  const hasValidApiKey = validateApiKey(request);
-  if (hasValidApiKey) {
-    return null;
+  const apiKey = process.env.API_KEY;
+  if (apiKey) {
+    const hasValidApiKey = validateApiKey(request);
+    if (hasValidApiKey) {
+      return null;
+    }
   }
 
   if (process.env.DEBUGGER) {
     console.log("[API Auth] Unauthorized request:", {
       path: request.nextUrl.pathname,
       hasSession: hasValidSession,
-      hasApiKey: hasValidApiKey,
+      apiKeyConfigured: !!process.env.API_KEY,
       hasAuthHeader: !!request.headers.get("authorization"),
     });
   }


### PR DESCRIPTION
# Changelog

Hi, sorry for the very quick release, someone flagged a potential security issue and I wanted to tackle it as soon as possible. Currently leaving the API_KEY unset is actually leaving all requests open, adding a key obviously blocks them, but after this update if you never set an api key all requests will be rejected unless you have a valid browser session.

**Important security fix**

- Fix API authentication to block all requests if an API_KEY is not set. #61 

**minor bugfix**

- Fix user dropdown closing cronjob modals #63 