### PR TITLE
fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,4 +328,4 @@ I would like to thank the following members for raising issues and help test/deb
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=fccview/cronmaster&type=Date)](https://www.star-history.com/#fccview/cronmaster&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=fccview/cronmaster&type=Date)](https://star-history.dera.page/#fccview/cronmaster&Date)


### PR DESCRIPTION
The star history chart in the README stopped rendering because the current provider is affected by GitHub stargazer API restrictions. This switches the chart to a working mirror so it displays correctly again. The change is limited to the chart image and its link in the README.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README’s Star History chart to use a new chart service URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->